### PR TITLE
AES-CBS with random IVs, HMAC, hash chains in messages, Applet with security alert

### DIFF
--- a/applet/src/main/java/applet/EmeraldApplet.java
+++ b/applet/src/main/java/applet/EmeraldApplet.java
@@ -31,8 +31,6 @@ public class EmeraldApplet extends Applet implements ExtendedLength {
     private final SecureChannelManagerOnCard secureChannelManagerOnCard;
     private final PasswordManagerSubApplet passwordManagerSubApplet;
 
-    private final byte[] ramBuffer;
-
     /**
      * Signals whether this applet instance is blocked due to security alert counter depleted.
      * @see #securityAlertCountdown
@@ -81,8 +79,6 @@ public class EmeraldApplet extends Applet implements ExtendedLength {
 
         // init SecureChannelManagerOnCard
         secureChannelManagerOnCard = new SecureChannelManagerOnCard(pin);
-
-        ramBuffer = JCSystem.makeTransientByteArray((short) 160, JCSystem.CLEAR_ON_DESELECT);
 
         passwordManagerSubApplet = new PasswordManagerSubApplet();
 
@@ -156,9 +152,7 @@ public class EmeraldApplet extends Applet implements ExtendedLength {
                     short dataLength = apdu.setIncomingAndReceive();
                     final short offsetCommandData = apdu.getOffsetCdata();
                     // decrypt incoming message
-                    Util.arrayCopyNonAtomic(apduBuffer, offsetCommandData, ramBuffer, (short) 0,
-                        dataLength);
-                    byte[] plaintext = secureChannelManagerOnCard.decrypt(ramBuffer);
+                    byte[] plaintext = secureChannelManagerOnCard.decrypt(apduBuffer, offsetCommandData, dataLength);
 
                     // forward decrypted message to SubApplet
                     byte[] responsePlaintext = passwordManagerSubApplet.process(plaintext);

--- a/applet/src/main/java/applet/EmeraldApplet.java
+++ b/applet/src/main/java/applet/EmeraldApplet.java
@@ -172,6 +172,8 @@ public class EmeraldApplet extends Applet implements ExtendedLength {
             // decrement security alert countdown or block the card if countdown is depleted
             if(securityAlertCountdown > 0){
                 securityAlertCountdown--;
+                // empty response
+                apdu.setOutgoingAndSend((short) 0, (short) 0);
             }
             else {
                 isAppletBlocked = true;

--- a/applet/src/main/java/applet/EmeraldApplet.java
+++ b/applet/src/main/java/applet/EmeraldApplet.java
@@ -12,13 +12,10 @@ import static applet.EmeraldProtocol.CLA_ENCRYPTED;
 import static applet.EmeraldProtocol.CLA_KEY_AGREEMENT;
 import static applet.EmeraldProtocol.CLA_PLAINTEXT;
 import static applet.EmeraldProtocol.PIN_LENGTH;
-import static applet.EmeraldProtocol.aesKeyDevelopmentTODO;
 import javacard.framework.APDU;
 import javacard.framework.Applet;
 import javacard.framework.ISO7816;
 import javacard.framework.ISOException;
-import javacard.framework.JCSystem;
-import javacard.framework.MultiSelectable;
 import javacard.framework.Util;
 import javacardx.apdu.ExtendedLength;
 
@@ -213,7 +210,6 @@ public class EmeraldApplet extends Applet implements ExtendedLength {
      * @see #deselect()
      */
     private void clearSessionData() {
-        // TODO overwrite session data in RAM with random data
         secureChannelManagerOnCard.clearSessionData();
     }
 }

--- a/applet/src/main/java/applet/EmeraldProtocol.java
+++ b/applet/src/main/java/applet/EmeraldProtocol.java
@@ -60,15 +60,6 @@ public class EmeraldProtocol {
      */
     public static final byte MESSAGE_OK_GET = (byte) 0x60;
 
-    // TODO we use static AES key until J-PAKE is implemented
-    public static final byte[] aesKeyDevelopmentTODO = new byte[]{ // TODO replace with J-PAKE
-        (byte) 0xFE, (byte) 0xED, (byte) 0xC0, (byte) 0xFF, (byte) 0xEE, (byte) 0x22,
-        (byte) 0xC0, (byte) 0xDE, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
-        (byte) 0x00, (byte) 0x00, (byte) 0xFE, (byte) 0xED, (byte) 0xC0, (byte) 0xFF,
-        (byte) 0xEE, (byte) 0x22, (byte) 0xC0, (byte) 0xDE, (byte) 0x00, (byte) 0x00,
-        (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
-        (byte) 0x00, (byte) 0x00};
-
     public static final byte PIN_LENGTH = (byte) 4;
 
     private EmeraldProtocol() {

--- a/applet/src/main/java/applet/PasswordManagerSubApplet.java
+++ b/applet/src/main/java/applet/PasswordManagerSubApplet.java
@@ -39,14 +39,14 @@ public class PasswordManagerSubApplet {
         }
     }
 
-    public byte[] process(byte[] message) {
+    public byte[] process(byte[] message) throws EmeraldProtocolException {
         byte slotId = message[PASSWORD_SLOT_ID_OFFSET];
 
         if (!(0 <= slotId && slotId < PASSWORD_SLOTS_COUNT)) {
             // incorrect password slot
             // attacker is trying to communicate with incorrect PIN
-            // TODO count incorrect counter and consider blocking the card
-            return null;
+            // count incorrect counter and consider blocking the card
+            throw new EmeraldProtocolException();
         }
 
         byte[] responsePlaintext = new byte[32];
@@ -56,8 +56,8 @@ public class PasswordManagerSubApplet {
                     || message[PASSWORD_LENGTH_OFFSET] > PASSWORD_SLOT_LENGTH) {
                     // invalid password length
                     // attacker is trying to communicate with incorrect PIN
-                    // TODO count incorrect counter and consider blocking the card
-                    return null;
+                    // count incorrect counter and consider blocking the card
+                    throw new EmeraldProtocolException();
                 }
                 // set password to selected slot
                 userPasswordSlots[slotId].setPassword(message, PASSWORD_VALUE_OFFSET,
@@ -80,8 +80,8 @@ public class PasswordManagerSubApplet {
             default:
                 // incorrect message
                 // attacker is trying to communicate with incorrect PIN
-                // TODO count incorrect counter and consider blocking the card
-                return null;
+                // count incorrect counter and consider blocking the card
+                throw new EmeraldProtocolException();
         }
         return responsePlaintext;
     }

--- a/applet/src/main/java/applet/SecureChannelManagerBase.java
+++ b/applet/src/main/java/applet/SecureChannelManagerBase.java
@@ -11,6 +11,8 @@ package applet;
     import javacard.security.KeyBuilder;
     import javacardx.crypto.Cipher;
 
+    import java.util.Arrays;
+
 public class SecureChannelManagerBase {
     private final AESKey aesKey;
     private final Cipher aesEncrypt;
@@ -18,14 +20,16 @@ public class SecureChannelManagerBase {
 
     private boolean secureChannelEstablished = false;
 
+    private static final byte ALG_AES_CBC_ISO9797_M2_BLOCK_SIZE = (byte) 16;
+
     public SecureChannelManagerBase() {
         // NOTE: We cannot use AES-GCM as JCardSim does not support AEADCipher.ALG_AES_GCM. It
         //       throws CryptoException with reason code CryptoException.NO_SUCH_ALGORITHM.
         //       https://github.com/licel/jcardsim/issues/153
 
         // init AES cipher
-        aesEncrypt = Cipher.getInstance(Cipher.ALG_AES_BLOCK_128_CBC_NOPAD, false);
-        aesDecrypt = Cipher.getInstance(Cipher.ALG_AES_BLOCK_128_CBC_NOPAD, false);
+        aesEncrypt = Cipher.getInstance(Cipher.ALG_AES_CBC_ISO9797_M2, false);
+        aesDecrypt = Cipher.getInstance(Cipher.ALG_AES_CBC_ISO9797_M2, false);
         aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES, KeyBuilder.LENGTH_AES_256, false);
     }
 
@@ -59,26 +63,22 @@ public class SecureChannelManagerBase {
             // key is not set
             throw new EmIllegalStateException();
         }
-        if (plaintext.length % 16 != 0) {
-            // plaintext length is not a multiple of AES block size (16 B)
-            throw new EmIllegalArgumentException();
-        }
-        byte[] ciphertext = new byte[plaintext.length];
-        aesEncrypt.doFinal(plaintext, (short) 0, (short) plaintext.length, ciphertext, (short) 0);
-        return ciphertext;
+        byte[] ciphertext = new byte[plaintext.length + ALG_AES_CBC_ISO9797_M2_BLOCK_SIZE];
+        final short ciphertextLength = aesEncrypt.doFinal(plaintext, (short) 0, (short) plaintext.length, ciphertext, (short) 0);
+        return Arrays.copyOf(ciphertext, ciphertextLength);
     }
 
-    public byte[] decrypt(byte[] ciphertext) {
+    public byte[] decrypt(byte[] ciphertext, short offset, short length) {
         if (!aesKey.isInitialized() || !isSecureChannelEstablished()) {
             // key is not set
             throw new EmIllegalStateException();
         }
-        if (ciphertext.length % 16 != 0) {
+        if (length % ALG_AES_CBC_ISO9797_M2_BLOCK_SIZE != 0) {
             // ciphertext length is not a multiple of AES block size (16 B)
             throw new EmIllegalArgumentException();
         }
-        byte[] plaintext = new byte[ciphertext.length];
-        aesDecrypt.doFinal(ciphertext, (short) 0, (short) ciphertext.length, plaintext, (short) 0);
-        return plaintext;
+        byte[] plaintext = new byte[length + ALG_AES_CBC_ISO9797_M2_BLOCK_SIZE];
+        final short plaintextLength = aesDecrypt.doFinal(ciphertext, offset, length, plaintext, (short) 0);
+        return Arrays.copyOf(plaintext, plaintextLength);
     }
 }

--- a/applet/src/main/java/applet/SecureChannelManagerBase.java
+++ b/applet/src/main/java/applet/SecureChannelManagerBase.java
@@ -7,29 +7,34 @@ Team Emerald (in alphabetical order):
 
 package applet;
 
-    import javacard.security.AESKey;
-    import javacard.security.HMACKey;
-    import javacard.security.KeyBuilder;
-    import javacard.security.MessageDigest;
-    import javacard.security.Signature;
-    import javacardx.crypto.Cipher;
+import javacard.framework.Util;
+import javacard.security.AESKey;
+import javacard.security.HMACKey;
+import javacard.security.KeyBuilder;
+import javacard.security.MessageDigest;
+import javacard.security.RandomData;
+import javacard.security.Signature;
+import javacardx.crypto.Cipher;
 
-    import java.util.Arrays;
+import java.util.Arrays;
 
 public class SecureChannelManagerBase {
+    private static final byte ALG_AES_CBC_ISO9797_M2_BLOCK_SIZE = (byte) 16;
+    private static final byte ALG_SHA_256_SIZE = (byte) 32;
+    private static final byte ALG_AES_CBC_ISO9797_M2_IV_SIZE = (byte) 16;
     private final AESKey aesKey;
     private final Cipher aesEncrypt;
     private final Cipher aesDecrypt;
     private final HMACKey hmacKey;
     private final Signature hmacSign;
     private final Signature hmacVerify;
-
-    private byte sessionMessageCounterEncrypted = 0;
-    private byte sessionMessageCounterDecrypted = 0;
-
+    private final MessageDigest hashChainGenerator;
+    private final byte[] hashChainEncryption;
+    private final byte[] hashChainDecryption;
+    private final MessageDigest kdf;
+    private final byte[] kdfBuffer;
+    private final RandomData ivGenerator;
     private boolean secureChannelEstablished = false;
-
-    private static final byte ALG_AES_CBC_ISO9797_M2_BLOCK_SIZE = (byte) 16;
 
     public SecureChannelManagerBase() {
         // NOTE: We cannot use AES-GCM as JCardSim does not support AEADCipher.ALG_AES_GCM. It
@@ -43,95 +48,151 @@ public class SecureChannelManagerBase {
         hmacVerify = Signature.getInstance(Signature.ALG_HMAC_SHA_256, false);
         aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES, KeyBuilder.LENGTH_AES_256, false);
         hmacKey = (HMACKey) KeyBuilder.buildKey(KeyBuilder.TYPE_HMAC, KeyBuilder.LENGTH_HMAC_SHA_256_BLOCK_64, false);
+
+        hashChainGenerator = MessageDigest.getInstance(MessageDigest.ALG_SHA_256, false);
+        hashChainEncryption = new byte[ALG_SHA_256_SIZE];
+        hashChainDecryption = new byte[ALG_SHA_256_SIZE];
+
+        kdf = MessageDigest.getInstance(MessageDigest.ALG_SHA_256, false);
+        kdfBuffer = new byte[kdf.getLength()];
+
+        ivGenerator = RandomData.getInstance(RandomData.ALG_SECURE_RANDOM);
     }
 
-    public void clearSessionData(){
+    public void clearSessionData() {
         secureChannelEstablished = false;
         aesKey.clearKey();
-        sessionMessageCounterEncrypted = 0;
-        sessionMessageCounterDecrypted = 0;
+        hmacKey.clearKey();
+        Util.arrayFillNonAtomic(hashChainEncryption, (short) 0, (short) hashChainEncryption.length,
+            (byte) 0);
+        Util.arrayFillNonAtomic(hashChainDecryption, (short) 0, (short) hashChainEncryption.length,
+            (byte) 0);
+        Util.arrayFillNonAtomic(kdfBuffer, (short) 0, (short) kdfBuffer.length, (byte) 0);
     }
 
-    public boolean isSecureChannelEstablished(){
+    public boolean isSecureChannelEstablished() {
         return secureChannelEstablished;
     }
 
-    void setKey(byte[] key) {
-        if ((short) (key.length * 8) != KeyBuilder.LENGTH_AES_256) {
-            // incorrect key length
+    void setKey(byte[] sessionKey) {
+        if ((short) (sessionKey.length * 8) != KeyBuilder.LENGTH_AES_256) {
+            // incorrect sessionKey length
             throw new EmIllegalArgumentException();
         }
-        if(isSecureChannelEstablished()){
-            // key was already set during this session
+        if (isSecureChannelEstablished()) {
+            // sessionKey was already set during this session
             throw new EmIllegalStateException();
         }
         secureChannelEstablished = true;
 
-        aesKey.setKey(key, (short) 0);
+        // configure AES
+        aesKey.setKey(sessionKey, (short) 0);
         aesEncrypt.init(aesKey, Cipher.MODE_ENCRYPT);
         aesDecrypt.init(aesKey, Cipher.MODE_DECRYPT);
 
-        MessageDigest hash = MessageDigest.getInstance(MessageDigest.ALG_SHA_256, false);
-        byte[] outputBytes = new byte[hash.getLength()];
-        final short hashLength = hash.doFinal(key, (short) 0, (short) key.length, outputBytes, (short) 0);
-        hmacKey.setKey(outputBytes, (short) 0, hashLength);
+        // configure HMAC
+        kdf.doFinal(sessionKey, (short) 0, (short) sessionKey.length, kdfBuffer, (short) 0);
+        hmacKey.setKey(kdfBuffer, (short) 0, kdf.getLength());
         hmacSign.init(hmacKey, Signature.MODE_SIGN);
         hmacVerify.init(hmacKey, Signature.MODE_VERIFY);
 
-        sessionMessageCounterEncrypted = 0;
-        sessionMessageCounterDecrypted = 0;
+        // generate first value of hash chain
+        kdf.doFinal(sessionKey, (short) 0, (short) sessionKey.length, kdfBuffer, (short) 0);
+        Util.arrayCopyNonAtomic(kdfBuffer, (short) 0, hashChainEncryption, (short) 0,
+            (short) hashChainEncryption.length);
+        Util.arrayCopyNonAtomic(kdfBuffer, (short) 0, hashChainDecryption, (short) 0,
+            (short) hashChainDecryption.length);
+    }
+
+    /**
+     * Set 16-byte IV for AES.
+     *
+     * @param ivBuffer buffer wit IV
+     * @param ivOffset offset of IV in buffer
+     */
+    public void setIv(byte[] ivBuffer, short ivOffset) {
+        aesEncrypt.init(aesKey, Cipher.MODE_ENCRYPT, ivBuffer, ivOffset,
+            ALG_AES_CBC_ISO9797_M2_IV_SIZE);
+        aesDecrypt.init(aesKey, Cipher.MODE_DECRYPT, ivBuffer, ivOffset,
+            ALG_AES_CBC_ISO9797_M2_IV_SIZE);
     }
 
     public byte[] encrypt(byte[] plaintext) {
-        if (!aesKey.isInitialized() || !isSecureChannelEstablished()) {
+        if (!aesKey.isInitialized() || !hmacKey.isInitialized() || !isSecureChannelEstablished()) {
             // key is not set
             throw new EmIllegalStateException();
         }
 
-        byte[] counterAndPlaintext = Arrays.copyOf(plaintext, 1 + plaintext.length);
-        counterAndPlaintext[counterAndPlaintext.length-1] = sessionMessageCounterEncrypted;
-        sessionMessageCounterEncrypted++;
+        byte[] ivBuffer = new byte[ALG_AES_CBC_ISO9797_M2_IV_SIZE];
+        ivGenerator.generateData(ivBuffer, (short) 0, ALG_AES_CBC_ISO9797_M2_IV_SIZE);
+        setIv(ivBuffer, (short) 0);
 
-        byte[] ciphertextBuffer = new byte[counterAndPlaintext.length + ALG_AES_CBC_ISO9797_M2_BLOCK_SIZE * 2];
-        final short ciphertextLength = aesEncrypt.doFinal(counterAndPlaintext, (short) 0, (short) counterAndPlaintext.length, ciphertextBuffer, (short) 0);
+        byte[] hashChainAndPlaintext = new byte[hashChainGenerator.getLength() + plaintext.length];
+        // copy current hash chain
+        Util.arrayCopyNonAtomic(hashChainEncryption, (short) 0, hashChainAndPlaintext,
+            (short) 0, (short) hashChainEncryption.length);
+        // copy plaintext
+        Util.arrayCopyNonAtomic(plaintext, (short) 0, hashChainAndPlaintext,
+            hashChainGenerator.getLength(), (short) plaintext.length);
+        // generate next hash chain
+        hashChainGenerator.doFinal(hashChainEncryption, (short) 0,
+            (short) hashChainEncryption.length, hashChainEncryption, (short) 0);
+
+        byte[] ciphertextBuffer = new byte[hashChainAndPlaintext.length + ALG_AES_CBC_ISO9797_M2_BLOCK_SIZE * 2];
+        final short ciphertextLength = aesEncrypt.doFinal(hashChainAndPlaintext, (short) 0, (short) hashChainAndPlaintext.length, ciphertextBuffer, (short) 0);
         byte[] ciphertext = Arrays.copyOf(ciphertextBuffer, ciphertextLength);
 
-        byte[] signBuff = new byte[256];
-        final short signLength = hmacSign.sign(ciphertext, (short) 0, (short) ciphertext.length, signBuff, (short) 0);
-        byte[] sign = Arrays.copyOf(signBuff, signLength);
+        byte[] hmacBuffer = new byte[256];
+        final short hmacLength = hmacSign.sign(ciphertext, (short) 0, (short) ciphertext.length, hmacBuffer, (short) 0);
+        byte[] hmac = Arrays.copyOf(hmacBuffer, hmacLength);
 
-        byte[] hmacAndCiphertext = new byte[sign.length + ciphertext.length];
-        System.arraycopy(sign, 0, hmacAndCiphertext, 0, sign.length);
-        System.arraycopy(ciphertext, 0, hmacAndCiphertext, sign.length, ciphertext.length);
-        return hmacAndCiphertext;
+        byte[] ivAndHmacAndCiphertext = new byte[ivBuffer.length + hmac.length + ciphertext.length];
+        short currentOffset = 0;
+        System.arraycopy(ivBuffer, 0, ivAndHmacAndCiphertext, currentOffset, ivBuffer.length);
+        currentOffset += ivBuffer.length;
+        System.arraycopy(hmac, 0, ivAndHmacAndCiphertext, currentOffset, hmac.length);
+        currentOffset += hmac.length;
+        System.arraycopy(ciphertext, 0, ivAndHmacAndCiphertext, currentOffset, ciphertext.length);
+        return ivAndHmacAndCiphertext;
     }
 
-    public byte[] decrypt(byte[] hmacAndCiphertext, short offset, short length) throws EmeraldProtocolException {
-        if (!aesKey.isInitialized() || !isSecureChannelEstablished()) {
+    public byte[] decrypt(byte[] ivAndHmacAndCiphertext, short offset, short length) throws EmeraldProtocolException {
+        if (!aesKey.isInitialized() || !hmacKey.isInitialized() || !isSecureChannelEstablished()) {
             // key is not set
             throw new EmIllegalStateException();
         }
-        byte[] hmac = Arrays.copyOfRange(hmacAndCiphertext, offset, offset + 32);
-        byte[] ciphertext = Arrays.copyOfRange(hmacAndCiphertext, offset + 32, offset + length);
+        short currentOffset = offset;
+        byte[] iv = Arrays.copyOfRange(ivAndHmacAndCiphertext, currentOffset,
+            currentOffset + ALG_AES_CBC_ISO9797_M2_IV_SIZE);
+        currentOffset += ALG_AES_CBC_ISO9797_M2_IV_SIZE;
+        byte[] hmac = Arrays.copyOfRange(ivAndHmacAndCiphertext, currentOffset,
+            currentOffset + 32);
+        currentOffset += 32;
+        byte[] ciphertext = Arrays.copyOfRange(ivAndHmacAndCiphertext, currentOffset,
+            offset + length);
 
         final boolean verified = hmacVerify.verify(ciphertext, (short) 0, (short) ciphertext.length, hmac, (short) 0, (short) hmac.length);
-        if(!verified){
+        if (!verified) {
             // invalid HMAC
             throw new EmeraldProtocolException();
         }
+        setIv(iv, (short) 0);
 
         byte[] plaintextBuffer = new byte[ciphertext.length + ALG_AES_CBC_ISO9797_M2_BLOCK_SIZE * 2];
         final short plaintextLength = aesDecrypt.doFinal(ciphertext, (short) 0, (short) ciphertext.length, plaintextBuffer, (short) 0);
-        byte[] counterAndPlaintext = Arrays.copyOf(plaintextBuffer, plaintextLength);
-        byte counter = counterAndPlaintext[counterAndPlaintext.length-1];
+        byte[] hashChainAndPlaintext = Arrays.copyOf(plaintextBuffer, plaintextLength);
 
-        if(counter != sessionMessageCounterDecrypted){
-            // invalid counter
+        // compare current value of hash chain with the one in decrypted plaintext
+        if (0 != Util.arrayCompare(hashChainAndPlaintext, (short) 0, hashChainDecryption, (short) 0,
+            (short) hashChainDecryption.length)) {
+            // invalid hash chain
             throw new EmeraldProtocolException();
         }
-        sessionMessageCounterDecrypted++;
+        // generate next hash chain
+        hashChainGenerator.doFinal(hashChainDecryption, (short) 0,
+            (short) hashChainDecryption.length, hashChainDecryption, (short) 0);
 
-        byte[] plaintext = Arrays.copyOfRange(counterAndPlaintext, 0, counterAndPlaintext.length-1);
+        byte[] plaintext = Arrays.copyOfRange(hashChainAndPlaintext, (short) hashChainDecryption.length, hashChainAndPlaintext.length);
         return plaintext;
     }
 }

--- a/applet/src/main/java/applet/SecureChannelManagerBase.java
+++ b/applet/src/main/java/applet/SecureChannelManagerBase.java
@@ -8,7 +8,10 @@ Team Emerald (in alphabetical order):
 package applet;
 
     import javacard.security.AESKey;
+    import javacard.security.HMACKey;
     import javacard.security.KeyBuilder;
+    import javacard.security.MessageDigest;
+    import javacard.security.Signature;
     import javacardx.crypto.Cipher;
 
     import java.util.Arrays;
@@ -17,6 +20,12 @@ public class SecureChannelManagerBase {
     private final AESKey aesKey;
     private final Cipher aesEncrypt;
     private final Cipher aesDecrypt;
+    private final HMACKey hmacKey;
+    private final Signature hmacSign;
+    private final Signature hmacVerify;
+
+    private byte sessionMessageCounterEncrypted = 0;
+    private byte sessionMessageCounterDecrypted = 0;
 
     private boolean secureChannelEstablished = false;
 
@@ -30,12 +39,17 @@ public class SecureChannelManagerBase {
         // init AES cipher
         aesEncrypt = Cipher.getInstance(Cipher.ALG_AES_CBC_ISO9797_M2, false);
         aesDecrypt = Cipher.getInstance(Cipher.ALG_AES_CBC_ISO9797_M2, false);
+        hmacSign = Signature.getInstance(Signature.ALG_HMAC_SHA_256, false);
+        hmacVerify = Signature.getInstance(Signature.ALG_HMAC_SHA_256, false);
         aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES, KeyBuilder.LENGTH_AES_256, false);
+        hmacKey = (HMACKey) KeyBuilder.buildKey(KeyBuilder.TYPE_HMAC, KeyBuilder.LENGTH_HMAC_SHA_256_BLOCK_64, false);
     }
 
     public void clearSessionData(){
         secureChannelEstablished = false;
         aesKey.clearKey();
+        sessionMessageCounterEncrypted = 0;
+        sessionMessageCounterDecrypted = 0;
     }
 
     public boolean isSecureChannelEstablished(){
@@ -56,6 +70,16 @@ public class SecureChannelManagerBase {
         aesKey.setKey(key, (short) 0);
         aesEncrypt.init(aesKey, Cipher.MODE_ENCRYPT);
         aesDecrypt.init(aesKey, Cipher.MODE_DECRYPT);
+
+        MessageDigest hash = MessageDigest.getInstance(MessageDigest.ALG_SHA_256, false);
+        byte[] outputBytes = new byte[hash.getLength()];
+        final short hashLength = hash.doFinal(key, (short) 0, (short) key.length, outputBytes, (short) 0);
+        hmacKey.setKey(outputBytes, (short) 0, hashLength);
+        hmacSign.init(hmacKey, Signature.MODE_SIGN);
+        hmacVerify.init(hmacKey, Signature.MODE_VERIFY);
+
+        sessionMessageCounterEncrypted = 0;
+        sessionMessageCounterDecrypted = 0;
     }
 
     public byte[] encrypt(byte[] plaintext) {
@@ -63,22 +87,51 @@ public class SecureChannelManagerBase {
             // key is not set
             throw new EmIllegalStateException();
         }
-        byte[] ciphertext = new byte[plaintext.length + ALG_AES_CBC_ISO9797_M2_BLOCK_SIZE];
-        final short ciphertextLength = aesEncrypt.doFinal(plaintext, (short) 0, (short) plaintext.length, ciphertext, (short) 0);
-        return Arrays.copyOf(ciphertext, ciphertextLength);
+
+        byte[] counterAndPlaintext = Arrays.copyOf(plaintext, 1 + plaintext.length);
+        counterAndPlaintext[counterAndPlaintext.length-1] = sessionMessageCounterEncrypted;
+        sessionMessageCounterEncrypted++;
+
+        byte[] ciphertextBuffer = new byte[counterAndPlaintext.length + ALG_AES_CBC_ISO9797_M2_BLOCK_SIZE * 2];
+        final short ciphertextLength = aesEncrypt.doFinal(counterAndPlaintext, (short) 0, (short) counterAndPlaintext.length, ciphertextBuffer, (short) 0);
+        byte[] ciphertext = Arrays.copyOf(ciphertextBuffer, ciphertextLength);
+
+        byte[] signBuff = new byte[256];
+        final short signLength = hmacSign.sign(ciphertext, (short) 0, (short) ciphertext.length, signBuff, (short) 0);
+        byte[] sign = Arrays.copyOf(signBuff, signLength);
+
+        byte[] hmacAndCiphertext = new byte[sign.length + ciphertext.length];
+        System.arraycopy(sign, 0, hmacAndCiphertext, 0, sign.length);
+        System.arraycopy(ciphertext, 0, hmacAndCiphertext, sign.length, ciphertext.length);
+        return hmacAndCiphertext;
     }
 
-    public byte[] decrypt(byte[] ciphertext, short offset, short length) {
+    public byte[] decrypt(byte[] hmacAndCiphertext, short offset, short length) throws EmeraldProtocolException {
         if (!aesKey.isInitialized() || !isSecureChannelEstablished()) {
             // key is not set
             throw new EmIllegalStateException();
         }
-        if (length % ALG_AES_CBC_ISO9797_M2_BLOCK_SIZE != 0) {
-            // ciphertext length is not a multiple of AES block size (16 B)
-            throw new EmIllegalArgumentException();
+        byte[] hmac = Arrays.copyOfRange(hmacAndCiphertext, offset, offset + 32);
+        byte[] ciphertext = Arrays.copyOfRange(hmacAndCiphertext, offset + 32, offset + length);
+
+        final boolean verified = hmacVerify.verify(ciphertext, (short) 0, (short) ciphertext.length, hmac, (short) 0, (short) hmac.length);
+        if(!verified){
+            // invalid HMAC
+            throw new EmeraldProtocolException();
         }
-        byte[] plaintext = new byte[length + ALG_AES_CBC_ISO9797_M2_BLOCK_SIZE];
-        final short plaintextLength = aesDecrypt.doFinal(ciphertext, offset, length, plaintext, (short) 0);
-        return Arrays.copyOf(plaintext, plaintextLength);
+
+        byte[] plaintextBuffer = new byte[ciphertext.length + ALG_AES_CBC_ISO9797_M2_BLOCK_SIZE * 2];
+        final short plaintextLength = aesDecrypt.doFinal(ciphertext, (short) 0, (short) ciphertext.length, plaintextBuffer, (short) 0);
+        byte[] counterAndPlaintext = Arrays.copyOf(plaintextBuffer, plaintextLength);
+        byte counter = counterAndPlaintext[counterAndPlaintext.length-1];
+
+        if(counter != sessionMessageCounterDecrypted){
+            // invalid counter
+            throw new EmeraldProtocolException();
+        }
+        sessionMessageCounterDecrypted++;
+
+        byte[] plaintext = Arrays.copyOfRange(counterAndPlaintext, 0, counterAndPlaintext.length-1);
+        return plaintext;
     }
 }

--- a/applet/src/main/java/applet/SecureChannelManagerBase.java
+++ b/applet/src/main/java/applet/SecureChannelManagerBase.java
@@ -46,8 +46,10 @@ public class SecureChannelManagerBase {
         aesDecrypt = Cipher.getInstance(Cipher.ALG_AES_CBC_ISO9797_M2, false);
         hmacSign = Signature.getInstance(Signature.ALG_HMAC_SHA_256, false);
         hmacVerify = Signature.getInstance(Signature.ALG_HMAC_SHA_256, false);
-        aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES, KeyBuilder.LENGTH_AES_256, false);
-        hmacKey = (HMACKey) KeyBuilder.buildKey(KeyBuilder.TYPE_HMAC, KeyBuilder.LENGTH_HMAC_SHA_256_BLOCK_64, false);
+        aesKey = (AESKey) KeyBuilder.buildKey(KeyBuilder.TYPE_AES, KeyBuilder.LENGTH_AES_256,
+            false);
+        hmacKey = (HMACKey) KeyBuilder.buildKey(KeyBuilder.TYPE_HMAC,
+            KeyBuilder.LENGTH_HMAC_SHA_256_BLOCK_64, false);
 
         hashChainGenerator = MessageDigest.getInstance(MessageDigest.ALG_SHA_256, false);
         hashChainEncryption = new byte[ALG_SHA_256_SIZE];
@@ -138,12 +140,15 @@ public class SecureChannelManagerBase {
         hashChainGenerator.doFinal(hashChainEncryption, (short) 0,
             (short) hashChainEncryption.length, hashChainEncryption, (short) 0);
 
-        byte[] ciphertextBuffer = new byte[hashChainAndPlaintext.length + ALG_AES_CBC_ISO9797_M2_BLOCK_SIZE * 2];
-        final short ciphertextLength = aesEncrypt.doFinal(hashChainAndPlaintext, (short) 0, (short) hashChainAndPlaintext.length, ciphertextBuffer, (short) 0);
+        byte[] ciphertextBuffer = new byte[hashChainAndPlaintext.length
+            + ALG_AES_CBC_ISO9797_M2_BLOCK_SIZE * 2];
+        final short ciphertextLength = aesEncrypt.doFinal(hashChainAndPlaintext, (short) 0,
+            (short) hashChainAndPlaintext.length, ciphertextBuffer, (short) 0);
         byte[] ciphertext = Arrays.copyOf(ciphertextBuffer, ciphertextLength);
 
         byte[] hmacBuffer = new byte[256];
-        final short hmacLength = hmacSign.sign(ciphertext, (short) 0, (short) ciphertext.length, hmacBuffer, (short) 0);
+        final short hmacLength = hmacSign.sign(ciphertext, (short) 0, (short) ciphertext.length,
+            hmacBuffer, (short) 0);
         byte[] hmac = Arrays.copyOf(hmacBuffer, hmacLength);
 
         byte[] ivAndHmacAndCiphertext = new byte[ivBuffer.length + hmac.length + ciphertext.length];
@@ -152,11 +157,13 @@ public class SecureChannelManagerBase {
         currentOffset += ivBuffer.length;
         System.arraycopy(hmac, 0, ivAndHmacAndCiphertext, currentOffset, hmac.length);
         currentOffset += hmac.length;
-        System.arraycopy(ciphertext, 0, ivAndHmacAndCiphertext, currentOffset, ciphertext.length);
+        System.arraycopy(ciphertext, 0, ivAndHmacAndCiphertext, currentOffset,
+            ciphertext.length);
         return ivAndHmacAndCiphertext;
     }
 
-    public byte[] decrypt(byte[] ivAndHmacAndCiphertext, short offset, short length) throws EmeraldProtocolException {
+    public byte[] decrypt(byte[] ivAndHmacAndCiphertext, short offset, short length)
+        throws EmeraldProtocolException {
         if (!aesKey.isInitialized() || !hmacKey.isInitialized() || !isSecureChannelEstablished()) {
             // key is not set
             throw new EmIllegalStateException();
@@ -171,15 +178,18 @@ public class SecureChannelManagerBase {
         byte[] ciphertext = Arrays.copyOfRange(ivAndHmacAndCiphertext, currentOffset,
             offset + length);
 
-        final boolean verified = hmacVerify.verify(ciphertext, (short) 0, (short) ciphertext.length, hmac, (short) 0, (short) hmac.length);
+        final boolean verified = hmacVerify.verify(ciphertext, (short) 0, (short) ciphertext.length,
+            hmac, (short) 0, (short) hmac.length);
         if (!verified) {
             // invalid HMAC
             throw new EmeraldProtocolException();
         }
         setIv(iv, (short) 0);
 
-        byte[] plaintextBuffer = new byte[ciphertext.length + ALG_AES_CBC_ISO9797_M2_BLOCK_SIZE * 2];
-        final short plaintextLength = aesDecrypt.doFinal(ciphertext, (short) 0, (short) ciphertext.length, plaintextBuffer, (short) 0);
+        byte[] plaintextBuffer = new byte[ciphertext.length
+            + ALG_AES_CBC_ISO9797_M2_BLOCK_SIZE * 2];
+        final short plaintextLength = aesDecrypt.doFinal(ciphertext, (short) 0,
+            (short) ciphertext.length, plaintextBuffer, (short) 0);
         byte[] hashChainAndPlaintext = Arrays.copyOf(plaintextBuffer, plaintextLength);
 
         // compare current value of hash chain with the one in decrypted plaintext
@@ -192,7 +202,7 @@ public class SecureChannelManagerBase {
         hashChainGenerator.doFinal(hashChainDecryption, (short) 0,
             (short) hashChainDecryption.length, hashChainDecryption, (short) 0);
 
-        byte[] plaintext = Arrays.copyOfRange(hashChainAndPlaintext, (short) hashChainDecryption.length, hashChainAndPlaintext.length);
-        return plaintext;
+        return Arrays.copyOfRange(hashChainAndPlaintext,
+            (short) hashChainDecryption.length, hashChainAndPlaintext.length);
     }
 }

--- a/applet/src/main/java/applet/SecureChannelManagerOnCard.java
+++ b/applet/src/main/java/applet/SecureChannelManagerOnCard.java
@@ -28,7 +28,6 @@ public class SecureChannelManagerOnCard extends SecureChannelManagerBase {
 
     public SecureChannelManagerOnCard(byte[] pin) {
         super();
-        // TODO: hash pin?
         jpakePassiveActor = new jpakePassiveActor(jPakeUserId, pin);
     }
 

--- a/applet/src/main/java/jpake/jpakeActor.java
+++ b/applet/src/main/java/jpake/jpakeActor.java
@@ -31,6 +31,11 @@ public abstract class jpakeActor {
     protected static BigInteger n = curvespec.getN(); /*order of subrgoup*/
     protected static BigInteger coFactor = curvespec.getH();
     protected byte[] userID;
+
+    /**
+     * Persistent PIN storage in EEPROM.
+     * NOTE: `javacard.framework.OwnerPIN` is not suitable as we need to read PIN value for J-PAKE
+     */
     protected BigInteger pinKey;
 
     public static ECCurve curve = curvespec.getCurve();

--- a/applet/src/test/java/applet/SecureChannelManagerOnCardTest.java
+++ b/applet/src/test/java/applet/SecureChannelManagerOnCardTest.java
@@ -32,7 +32,7 @@ class SecureChannelManagerOnCardTest {
             (byte) 0xC0, (byte) 0xDE};
         byte[] ciphertext = manager.encrypt(plaintext);
         Assert.assertFalse(Arrays.equals(plaintext, ciphertext));
-        byte[] decrypted = manager.decrypt(ciphertext);
+        byte[] decrypted = manager.decrypt(ciphertext, (short)0, (short) ciphertext.length);
         Assert.assertArrayEquals(plaintext, decrypted);
     }
 }

--- a/applet/src/test/java/applet/SecureChannelManagerOnCardTest.java
+++ b/applet/src/test/java/applet/SecureChannelManagerOnCardTest.java
@@ -16,7 +16,7 @@ class SecureChannelManagerOnCardTest {
     private static final byte[] TEST_PIN = new byte[]{1, 2, 3, 4};
 
     @Test
-    void testEncryptDecrypt() {
+    void testEncryptDecrypt() throws EmeraldProtocolException {
         SecureChannelManagerOnCard manager = new SecureChannelManagerOnCard(TEST_PIN);
         byte[] testKey = new byte[]{
             (byte) 0xFE, (byte) 0xED, (byte) 0xC0, (byte) 0xFF, (byte) 0xEE, (byte) 0x22,
@@ -34,5 +34,29 @@ class SecureChannelManagerOnCardTest {
         Assert.assertFalse(Arrays.equals(plaintext, ciphertext));
         byte[] decrypted = manager.decrypt(ciphertext, (short)0, (short) ciphertext.length);
         Assert.assertArrayEquals(plaintext, decrypted);
+    }
+
+    @Test
+    void testEncryptDecryptRepeated() throws EmeraldProtocolException {
+        SecureChannelManagerOnCard manager = new SecureChannelManagerOnCard(TEST_PIN);
+        byte[] testKey = new byte[]{
+            (byte) 0xFE, (byte) 0xED, (byte) 0xC0, (byte) 0xFF, (byte) 0xEE, (byte) 0x22,
+            (byte) 0xC0, (byte) 0xDE, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0xFE, (byte) 0xED, (byte) 0xC0, (byte) 0xFF,
+            (byte) 0xEE, (byte) 0x22, (byte) 0xC0, (byte) 0xDE, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00};
+        manager.setKey(testKey);
+        byte[] plaintext = new byte[]{
+            (byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0xC0, (byte) 0xDE};
+        for (int i = 0; i < 300; i++) {
+            // 300 > range of sessionMessageCounterEncrypted in SecureChannelManagerBase
+            byte[] ciphertext = manager.encrypt(plaintext);
+            Assert.assertFalse(Arrays.equals(plaintext, ciphertext));
+            byte[] decrypted = manager.decrypt(ciphertext, (short)0, (short) ciphertext.length);
+            Assert.assertArrayEquals(plaintext, decrypted);
+        }
     }
 }

--- a/applet/src/test/java/e2e/EmeraldAppletAPDUTest.java
+++ b/applet/src/test/java/e2e/EmeraldAppletAPDUTest.java
@@ -71,7 +71,7 @@ public class EmeraldAppletAPDUTest extends BaseTest {
             Assert.assertNotNull(response);
             Assert.assertEquals(0x9000, response.getSW());
 
-            byte[] responsePlaintext = secureChannelManager.decrypt(response.getData());
+            byte[] responsePlaintext = secureChannelManager.decrypt(response.getData(), (short)0, (short) response.getData().length);
             Assert.assertEquals(responsePlaintext.length, MESSAGE_LENGTH);
             Assert.assertEquals(responsePlaintext[MESSAGE_TYPE_OFFSET], MESSAGE_OK_SET);
         }
@@ -101,7 +101,7 @@ public class EmeraldAppletAPDUTest extends BaseTest {
             Assert.assertNotNull(response);
             Assert.assertEquals(0x9000, response.getSW());
 
-            byte[] responsePlaintext = secureChannelManager.decrypt(response.getData());
+            byte[] responsePlaintext = secureChannelManager.decrypt(response.getData(), (short)0, (short) response.getData().length);
             Assert.assertEquals(responsePlaintext.length, MESSAGE_LENGTH);
             Assert.assertEquals(responsePlaintext[MESSAGE_TYPE_OFFSET], MESSAGE_OK_SET);
             //endregion
@@ -118,7 +118,7 @@ public class EmeraldAppletAPDUTest extends BaseTest {
             Assert.assertNotNull(response);
             Assert.assertEquals(0x9000, response.getSW());
 
-            responsePlaintext = secureChannelManager.decrypt(response.getData());
+            responsePlaintext = secureChannelManager.decrypt(response.getData(), (short)0, (short) response.getData().length);
             Assert.assertEquals(responsePlaintext.length, MESSAGE_LENGTH);
             Assert.assertEquals(responsePlaintext[MESSAGE_TYPE_OFFSET], MESSAGE_OK_GET);
             Assert.assertEquals(responsePlaintext[PASSWORD_SLOT_ID_OFFSET], passwordSlotId);

--- a/emApplication/src/main/java/emapplication/EmeraldApplicationCli.java
+++ b/emApplication/src/main/java/emapplication/EmeraldApplicationCli.java
@@ -37,12 +37,10 @@ import java.util.Scanner;
 public class EmeraldApplicationCli {
     public static final String AID = "0102030405060708090102";
     public static final byte[] AID_BYTES = Util.hexStringToByteArray(AID);
-
-    final CardManager cardManager;
-    SecureChannelManagerOnComputer secureChannelManagerOnComputer;
-
     public static final String UI_ERROR_IN_COMMUNICATION = "Error: Error in communication with the card.";
     public static final String UI_DETAILED_INFO_ABOUT_ERROR = "Detailed info about this error:";
+    final CardManager cardManager;
+    SecureChannelManagerOnComputer secureChannelManagerOnComputer;
 
 
     public EmeraldApplicationCli() {
@@ -90,8 +88,7 @@ public class EmeraldApplicationCli {
             e.printStackTrace();
             secureChannelManagerOnComputer.clearSessionData();
             return;
-        }
-        catch (EmProtocolError | EmeraldProtocolException e){
+        } catch (EmProtocolError | EmeraldProtocolException e) {
             System.err.println(UI_ERROR_IN_COMMUNICATION);
             System.err.println("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
             System.err.println("@ \"IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!\" @");
@@ -165,7 +162,7 @@ public class EmeraldApplicationCli {
     }
 
     public void setPassword(byte passwordSlotId, String password)
-        throws CardException, EmProtocolError {
+        throws CardException, EmProtocolError, EmeraldProtocolException {
         System.out.println(String.format("PC --> SC: Set password `%s` to slot %d.",
             password, passwordSlotId));
 
@@ -183,7 +180,8 @@ public class EmeraldApplicationCli {
         ResponseAPDU response = cardManager.transmit(command);
         checkApduResponseStatus(response);
 
-        byte[] responsePlaintext = secureChannelManagerOnComputer.decrypt(response.getData());
+        byte[] responsePlaintext = secureChannelManagerOnComputer.decrypt(response.getData(),
+            (short) 0, (short) response.getData().length);
         // check responsePlaintext
         if (responsePlaintext.length != MESSAGE_LENGTH) {
             throw new EmProtocolError(
@@ -232,7 +230,7 @@ public class EmeraldApplicationCli {
 
     }
 
-    public String getPassword(byte passwordSlotId) throws CardException, EmProtocolError {
+    public String getPassword(byte passwordSlotId) throws CardException, EmProtocolError, EmeraldProtocolException {
         System.out.println(String.format("PC --> SC: Get password from slot %d.", passwordSlotId));
 
         byte[] plaintext = new byte[MESSAGE_LENGTH];
@@ -245,7 +243,8 @@ public class EmeraldApplicationCli {
 
         checkApduResponseStatus(response);
 
-        byte[] responsePlaintext = secureChannelManagerOnComputer.decrypt(response.getData());
+        byte[] responsePlaintext = secureChannelManagerOnComputer.decrypt(response.getData(),
+            (short) 0, (short) response.getData().length);
 
         checkMessageResponse(responsePlaintext, MESSAGE_LENGTH, MESSAGE_OK_GET, passwordSlotId);
 
@@ -275,7 +274,7 @@ public class EmeraldApplicationCli {
         System.out.println("##################################################");
     }
 
-    public void demoPasswordStorage() throws CardException, EmProtocolError {
+    public void demoPasswordStorage() throws CardException, EmProtocolError, EmeraldProtocolException {
         System.out.println("##################################################");
         System.out.println("Begin: demo password storage");
 


### PR DESCRIPTION
New encryption scheme:

Initialization vector || HMAC || AES-CBC with *ISO 9797 method 2* padding ( hashchain || plaintext )

Applet now blocks itself after 3 security alerts, e. g. incorrect PIN.
